### PR TITLE
Added MAXIMUM_CHARACTER_LENGTH environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,12 @@ ADD test_api.py .
 ENV JAVA_XMX 4g
 ENV ANNOTATORS tokenize,ssplit,parse
 ENV TIMEOUT_MILLISECONDS 15000
+ENV MAXIMUM_CHARACTER_LENGTH 100000
 
 ENV PORT 9000
 
 EXPOSE $PORT
 
 
-CMD java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -annotators "$ANNOTATORS" -port $PORT -timeout $TIMEOUT_MILLISECONDS
+CMD java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -annotators "$ANNOTATORS" -port $PORT -timeout $TIMEOUT_MILLISECONDS -maxCharLength $MAXIMUM_CHARACTER_LENGTH
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ the `JAVA_XMX` environment variable. Here, we're giving it 3GB:
 docker run -e JAVA_XMX=3g -p 9000:9000 -ti nlpbox/corenlp
 ```
 
+The default maximum characters that CoreNLP server will take at one time is 100000 (one hundred thousand)
+This can be changed by setting the `MAXIMUM_CHARACTER_LENGTH` environment variable as shown below:
+
+```
+docker run -e MAXIMUM_CHARACTER_LENGTH=500000 -p 9000:9000 -ti nlpbox/corenlp
+```
 
 In order to build and run the container from scratch (e.g. if you want to use the most current release of Stanford CoreNLP, type:
 


### PR DESCRIPTION
Added the MAXIMUM_CHARACTER_LENGTH environment variable to adjust the maximum amount of characters that the CoreNLP server will take at one time.

Updated README.md to reflect the update.